### PR TITLE
Correct mysql2 version

### DIFF
--- a/temporary-fixes.json
+++ b/temporary-fixes.json
@@ -3,7 +3,7 @@
     {
       "matchManagers": ["bundler"],
       "matchPackageNames": ["mysql2"],
-      "allowedVersions": "<=0.5.6",
+      "allowedVersions": "<=0.5.5",
       "description": "Departure not compatible: https://github.com/departurerb/departure/issues/107"
     }
   ]


### PR DESCRIPTION
I specified this wrong in https://github.com/powerhome/renovate-config/pull/18.