### PR TITLE
Revert "Disable bundler upgrades"

### DIFF
--- a/temporary-fixes.json
+++ b/temporary-fixes.json
@@ -10,11 +10,6 @@
       "allowedVersions": "<1.13.0",
       "versionCompatibility": "^(?<version>[^-]+)(?<compatibility>-.*)?$",
       "description": "v1.13 is only tested on k8s > 1.24, while PAC uses 1.22: https://docs.percona.com/percona-operator-for-mysql/pxc/ReleaseNotes/Kubernetes-Operator-for-PXC-RN1.13.0.html#supported-platforms"
-    },
-    {
-      "matchPackageNames": ["bundler"],
-      "enabled": false,
-      "description": "Bundler upgrades are not supported until https://github.com/renovatebot/renovate/pull/27460 is available."
     }
   ]
 }


### PR DESCRIPTION
Reverts powerhome/renovate-config#25 because https://github.com/renovatebot/renovate/pull/27460 is now available in public Renovate.