### PR TITLE
Avoid auth bug in grafana-operator 5.8.1

### DIFF
--- a/temporary-fixes.json
+++ b/temporary-fixes.json
@@ -7,8 +7,8 @@
     },
     {
       "matchPackageNames": ["ghcr.io/grafana/grafana-operator"],
-      "allowedVersions": "<5.9.0",
-      "description": "See https://github.com/powerhome/pac/pull/1983"
+      "allowedVersions": "<5.8.1",
+      "description": "See https://github.com/powerhome/pac/pull/1983 and https://github.com/grafana/grafana-operator/pull/1500"
     }
   ]
 }


### PR DESCRIPTION
The grafana-operator introduced a bug in 5.8.1 which ignores the custom HTTP auth header information stored in the `securetJsonData` property.[^1] The effect is that none of the grafana dashboards load because the HTTP requests to the influxdb lack proper authentication information.

We're currently awaiting CRD upgrades in PAC[^2] so we can upgrade to an operator version past this bug. However, until then a downgrade to 5.8.0 should get auth / the dashboards working again.

[^1]: https://github.com/grafana/grafana-operator/pull/1500
[^2]: https://github.com/powerhome/pac/pull/1983

See also: https://github.com/powerhome/example-rails-app/pull/554