### PR TITLE
Keep ruby versions in sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ RUN mkdir $NVM_DIR \
     && npm config set tarball /tmp/node-headers.tgz
 ```
 
+## group-ruby-version
+Groups Ruby version updates from a Dockerfile base image and a `.tool-versions` file into a single PR, so both stay in sync.
+
+If a repo only has one of the two, that one is updated on its own — no extra effect on non-Ruby projects.
+
+Usage: `"extends": ["github>powerhome/renovate-config:group-ruby-version"]`
+
 ## add-labels
 Adds standard label(s) to Renovate PRs.
 

--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
         "powerhome/renovate-config:use-internal-registry",
         "powerhome/renovate-config:krane-templates-image-versions",
         "powerhome/renovate-config:dockerfile-dep-versions",
+        "powerhome/renovate-config:group-ruby-version",
         "powerhome/renovate-config:add-labels",
         "powerhome/renovate-config:ignore-stalebot-action",
         "powerhome/renovate-config:ignore-reviewdog-action"

--- a/group-ruby-version.json
+++ b/group-ruby-version.json
@@ -1,8 +1,9 @@
 {
   "packageRules": [
     {
-      "matchManagers": ["dockerfile", "asdf"],
-      "matchPackageNames": ["ruby"],
+      "description": "Keep Ruby version in sync",
+      "matchManagers": ["dockerfile", "ruby-version", "asdf"],
+      "matchDepNames": ["ruby"],
       "groupName": "ruby version"
     }
   ]

--- a/group-ruby-version.json
+++ b/group-ruby-version.json
@@ -4,7 +4,8 @@
       "description": "Keep Ruby version in sync",
       "matchManagers": ["dockerfile", "ruby-version", "asdf"],
       "matchDepNames": ["ruby"],
-      "groupName": "ruby version"
+      "groupName": "ruby version",
+      "commitMessageTopic": "Ruby"
     }
   ]
 }

--- a/group-ruby-version.json
+++ b/group-ruby-version.json
@@ -1,0 +1,9 @@
+{
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile", "asdf"],
+      "matchPackageNames": ["ruby"],
+      "groupName": "ruby version"
+    }
+  ]
+}


### PR DESCRIPTION
Ruby projects tend to use a base docker image. When they also specify
local version manager configuration - e.g. asdf .tool-version - 
the ruby versions can drift. This is an attempt to make renovate
keep them in sync.