### PR TITLE
[GOG-1764] Add global Renovate rule to not update multi_json past 1.20.x

### DIFF
--- a/temporary-fixes.json
+++ b/temporary-fixes.json
@@ -9,6 +9,12 @@
       "matchPackageNames": ["ghcr.io/grafana/grafana-operator"],
       "allowedVersions": "<5.8.1",
       "description": "See https://github.com/powerhome/pac/pull/1983 and https://github.com/grafana/grafana-operator/pull/1500"
+    },
+    {
+      "matchDatasources": ["rubygems"],
+      "matchPackageNames": ["multi_json"],
+      "allowedVersions": "<1.21",
+      "description": "See https://runway.powerhrg.com/backlog_items/GOG-1764"
     }
   ]
 }


### PR DESCRIPTION
Due to parsing errors in multiple projects (pac-deployer with Krane, and now Milano GitHub response parsing), this will make sure that Renovate shouldn't upgrade the `multi_json` gem past 1.20.x.