### PR TITLE
Revert "[GOG-1764] Add global Renovate rule to not update multi_json past 1.20.x"

### DIFF
--- a/temporary-fixes.json
+++ b/temporary-fixes.json
@@ -9,12 +9,6 @@
       "matchPackageNames": ["ghcr.io/grafana/grafana-operator"],
       "allowedVersions": "<5.8.1",
       "description": "See https://github.com/powerhome/pac/pull/1983 and https://github.com/grafana/grafana-operator/pull/1500"
-    },
-    {
-      "matchDatasources": ["rubygems"],
-      "matchPackageNames": ["multi_json"],
-      "allowedVersions": "<1.21",
-      "description": "See https://runway.powerhrg.com/backlog_items/GOG-1764"
     }
   ]
 }


### PR DESCRIPTION
We no longer need this restriction in place. `multi_json` [has been bumped to v1.21.1](https://github.com/sferik/multi_json/commit/ee162828fba2693b1e07de6b26d3b9d8d0310a50#diff-c4eeb704909d6e63d7ddf3becf4623d13516c10f04d50ff9f700c7252e9098c5) to address the bug we were wanting to avoid.

There are no open Renovate PRs to bump this gem to a problem version, so as Renovate keeps running in repos, we shouldn't have any bumps to the problem version of v1.21.0.