### PR TITLE
[GOG-1828] Add rules for deb-based OS package updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,31 @@ RUN mkdir $NVM_DIR \
     && npm config set tarball /tmp/node-headers.tgz
 ```
 
+## os-package-versions
+Allows Renovate to update specifically labeled Ubuntu and Debian package versions in Dockerfiles.
+
+Usage: `"extends": ["github>powerhome/renovate-config:os-package-versions"]`
+
+Supported datasource aliases:
+
+- `ubuntu-2404`
+- `ubuntu-2604`
+- `debian-12`
+- `debian-13`
+- `debian-14`
+
+Dockerfile syntax example:
+
+```Dockerfile
+FROM ubuntu:24.04
+
+# renovate: datasource=ubuntu-2404 depName=curl
+ARG CURL_VERSION=8.5.0-2ubuntu10.6
+RUN apt-get update && \
+    apt-get install -y curl="${CURL_VERSION}" && \
+    apt-get clean
+```
+
 ## group-ruby-version
 Groups Ruby version updates from a Dockerfile base image and a `.tool-versions` file into a single PR, so both stay in sync.
 

--- a/default.json
+++ b/default.json
@@ -7,6 +7,7 @@
         "powerhome/renovate-config:use-internal-registry",
         "powerhome/renovate-config:krane-templates-image-versions",
         "powerhome/renovate-config:dockerfile-dep-versions",
+        "powerhome/renovate-config:os-package-versions",
         "powerhome/renovate-config:group-ruby-version",
         "powerhome/renovate-config:add-labels",
         "powerhome/renovate-config:ignore-stalebot-action",

--- a/os-package-versions.json
+++ b/os-package-versions.json
@@ -1,0 +1,102 @@
+{
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/(^|/)Dockerfile(\\.[^/]*)?$/"
+      ],
+      "matchStrings": [
+        "#\\s*renovate\\s*:\\s*datasource=(?<depType>ubuntu-2404|ubuntu-2604|debian-12|debian-13|debian-14|debian-15)\\s+depName=(?<depName>\\S+)(?:[^\\r\\n]*)[\\r\\n]+\\s*(?:ENV|ARG)\\s+[A-Za-z_][A-Za-z0-9_]*(?:=|\\s+)['\"]?(?<currentValue>[^'\"\\s]+)['\"]?"
+      ],
+      "datasourceTemplate": "deb",
+      "versioningTemplate": "deb"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "deb"
+      ],
+      "matchDepTypes": [
+        "ubuntu-2404"
+      ],
+      "groupName": "ubuntu 24.04 packages",
+      "registryUrls": [
+        "https://archive.ubuntu.com/ubuntu/?suite=noble&components=main,universe&binaryArch=amd64",
+        "https://archive.ubuntu.com/ubuntu/?suite=noble-updates&components=main,universe&binaryArch=amd64",
+        "https://archive.ubuntu.com/ubuntu/?suite=noble-security&components=main,universe&binaryArch=amd64"
+      ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "deb"
+      ],
+      "matchDepTypes": [
+        "ubuntu-2604"
+      ],
+      "groupName": "ubuntu 26.04 packages",
+      "registryUrls": [
+        "https://archive.ubuntu.com/ubuntu/?suite=resolute&components=main,universe&binaryArch=amd64",
+        "https://archive.ubuntu.com/ubuntu/?suite=resolute-updates&components=main,universe&binaryArch=amd64",
+        "https://archive.ubuntu.com/ubuntu/?suite=resolute-security&components=main,universe&binaryArch=amd64"
+      ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "deb"
+      ],
+      "matchDepTypes": [
+        "debian-12"
+      ],
+      "groupName": "debian 12 packages",
+      "registryUrls": [
+        "https://deb.debian.org/debian/?suite=bookworm&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://deb.debian.org/debian/?suite=bookworm-updates&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://security.debian.org/debian-security/?suite=bookworm-security&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64"
+      ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "deb"
+      ],
+      "matchDepTypes": [
+        "debian-13"
+      ],
+      "groupName": "debian 13 packages",
+      "registryUrls": [
+        "https://deb.debian.org/debian/?suite=trixie&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://deb.debian.org/debian/?suite=trixie-updates&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://security.debian.org/debian-security/?suite=trixie-security&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64"
+      ]
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchDatasources": [
+        "deb"
+      ],
+      "matchDepTypes": [
+        "debian-14"
+      ],
+      "groupName": "debian 14 packages",
+      "registryUrls": [
+        "https://deb.debian.org/debian/?suite=forky&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://deb.debian.org/debian/?suite=forky-updates&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64",
+        "https://security.debian.org/debian-security/?suite=forky-security&components=main,contrib,non-free,non-free-firmware&binaryArch=amd64"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
In order to allow us to manage Debian-based OS updates easier in Dockerfiles, this preset adds the ability to use something like
```
# renovate: datasource=ubuntu-2404 depName=git
```
in order to let Renovate update the version of `git` for an image based on Ubuntu 24.04. An example of this can be seen [here](https://github.com/c-gerke/renovate-os-package-example/blob/main/dockerfiles/Dockerfile.ubuntu-2404#L9).

A full collection of the Renovate PRs that would be generated for the different distros' base images can be viewed in [this repo](https://github.com/c-gerke/renovate-os-package-example/pulls), with each Renovate PR generating a valid image after the package upgrade via GitHub Actions.

This was driven by noticing that the work in https://github.com/powerhome/pac-deployer/pull/127 was only partially complete after cherry picking some of the work from my fork in an effort to make the pac-deployer image builds more repeatable.