### PR TITLE
Add a (non-global) rule to update pac-deployer images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ Allows Renovate the ability to bump ci-kubed versions in Jenkinsfiles.
 
 Usage: `"extends": ["github>powerhome/renovate-config:ci-kubed-versioning"]`
 
+## deployer-image-versioning
+Allows Renovate the ability to bump pac-deployer image versions in deployer bash scripts.
+Legacy `main-<sha>-<build>` and `master-<sha>-<build>` tags are migrated to
+the latest GitHub release, then future `vX.Y.Z` tags are updated from GitHub
+releases.
+
+Usage: `"extends": ["github>powerhome/renovate-config:deployer-image-versioning"]`
+
 ## use-internal-registry
 Allows Renovate usage of Power's npm-registry.
 

--- a/deployer-image-versioning.json
+++ b/deployer-image-versioning.json
@@ -1,0 +1,46 @@
+{
+    "customManagers": [
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)bin/.*$/",
+                "/(^|/)deploy/.*$/",
+                "/(^|/)scripts?/.*$/",
+                "/(^|/)[^/.]+$/",
+                "/\\.sh$/"
+            ],
+            "matchStrings": [
+                "(?<prefix>DEPLOYER_IMAGE\\s*=\\s*[\"']?image-registry\\.powerapp\\.cloud/app/deployer:)(?:latest|(?:main|master)-[a-f0-9]{40}-\\d+|PR-\\d+-[a-f0-9]{40}-\\d+(?:-amd64)?)"
+            ],
+            "currentValueTemplate": "0.0.0",
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "powerhome/pac-deployer",
+            "autoReplaceStringTemplate": "{{{prefix}}}{{{newValue}}}"
+        },
+        {
+            "customType": "regex",
+            "managerFilePatterns": [
+                "/(^|/)bin/.*$/",
+                "/(^|/)deploy/.*$/",
+                "/(^|/)scripts?/.*$/",
+                "/(^|/)[^/.]+$/",
+                "/\\.sh$/"
+            ],
+            "matchStrings": [
+                "(?<prefix>DEPLOYER_IMAGE\\s*=\\s*[\"']?image-registry\\.powerapp\\.cloud/app/deployer:)(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
+            ],
+            "datasourceTemplate": "github-releases",
+            "depNameTemplate": "powerhome/pac-deployer",
+            "autoReplaceStringTemplate": "{{{prefix}}}{{{newValue}}}"
+        }
+    ],
+    "packageRules": [
+        {
+            "matchManagers": ["custom.regex"],
+            "matchDepNames": ["powerhome/pac-deployer"],
+            "groupName": null,
+            "prHourlyLimit": 0,
+            "prConcurrentLimit": 0
+        }
+    ]
+}


### PR DESCRIPTION
## What changed

Adds a shared Renovate preset for keeping PAC deployer wrapper scripts on the latest released `pac-deployer` image, but doesn't add it to the default ruleset yet.

The new `deployer-image-versioning` preset scans common bash script locations like:

- `bin/deployer`
- `deploy/bin/deployer`
- `bin/container/deployer`
- `scripts/*`
- root-level extensionless scripts like `tridentctl-pac`
- `*.sh`

It looks for shared deployer image assignments like:

```bash
DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:main-559f8a815f07c3e04dc82bf416c403ef80f6eacb-42"
```

and will update them to the latest GitHub release tag from `powerhome/pac-deployer`, for example:

```bash
DEPLOYER_IMAGE="image-registry.powerapp.cloud/app/deployer:v1.0.0"
```

## Why

A lot of repos pin `pac-deployer` by old `main-<sha>-<build>`, `master-<sha>-<build>`, `PR-*`, or `latest` tags. Now with the proposed `pac-deployer` release process (https://github.com/powerhome/pac-deployer/pull/154), we can move those wrappers to stable release tags and let Renovate keep them current.

This intentionally only matches the shared PAC deployer image:

```text
image-registry.powerapp.cloud/app/deployer
```

It will not update project-specific deployer images like:

```text
image-registry.powerapp.cloud/talkbox/deployer
image-registry.powerapp.cloud/nitro-talkbox/deployer
```

## Validation

- Validated the preset with `renovate-config-validator`
- Smoke-tested the matcher against local deployer script examples
