### PR TITLE
Manage Helm Percona release versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Usage: `"extends": ["github>powerhome/renovate-config:ignore-reviewdog-action"]`
 ## Percona presets
 
 ### percona-postgresql-versions
-Restricts Percona PostgreSQL-related Docker updates to images certified together in the blessed Percona PostgreSQL Operator release.
+Restricts Percona PostgreSQL-related Docker and Helm chart updates to versions certified together in the blessed Percona PostgreSQL Operator release.
 
 Usage: `"extends": ["github>powerhome/renovate-config:percona-postgresql-versions"]`
 
@@ -131,6 +131,7 @@ This preset:
 
 - Groups Percona PostgreSQL dependency updates into one Renovate PR.
 - Restricts `allowedVersions` to the certified image versions from Percona's release notes.
+- Restricts the `pg-db` and `pg-operator` Helm charts to the blessed Percona PostgreSQL Operator version.
 - Keeps PMM client updates on the current major version, so a project on PMM `2.x` is not offered PMM `3.x`.
 - Keeps PostgreSQL image updates on the current PostgreSQL major version. For example, a project on PostgreSQL 14 only matches approved PostgreSQL 14 image tags.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ This preset:
 - Keeps PostgreSQL image updates on the current PostgreSQL major version. For example, a project on PostgreSQL 14 only matches approved PostgreSQL 14 image tags.
 
 ### percona-pxc-versions
-Restricts Percona PXC-related Docker updates to images certified together in the blessed Percona PXC Operator release.
+Restricts Percona PXC-related Docker and Helm chart updates to versions certified together in the blessed Percona PXC Operator release.
 
 Usage: `"extends": ["github>powerhome/renovate-config:percona-pxc-versions"]`
 
@@ -144,6 +144,7 @@ This preset:
 
 - Groups Percona PXC dependency updates into one Renovate PR.
 - Restricts `allowedVersions` to the certified image versions from Percona's release notes.
+- Restricts the `pxc-db` and `pxc-operator` Helm charts to the blessed Percona PXC Operator version.
 - Keeps PXC and XtraBackup updates on the current MySQL compatibility line. For example, a project on `8.0.x` is not offered `8.4.x`, and a project on `5.7.x` is not offered `8.0.x`.
 
 ### Updating Percona presets

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -15,13 +15,17 @@ class PerconaDigestUpdater
 
   DIGEST_PATTERN = /\A[a-f0-9]{64}\z/i
 
-  OperatorConfig = Struct.new(:name, :github_repo, :docs_base_url, :docs_pattern, :config_file, keyword_init: true) do
+  OperatorConfig = Struct.new(:name, :github_repo, :docs_base_url, :docs_pattern, :config_file, :helm_charts, keyword_init: true) do
     def release_notes_url(version)
       "#{docs_base_url}/#{docs_pattern % version}"
     end
 
     def display_name
       name.upcase
+    end
+
+    def helm_chart_names
+      helm_charts || []
     end
   end
 
@@ -271,6 +275,19 @@ class PerconaDigestUpdater
     private_class_method :postgres_major_matcher
   end
 
+  RenovateHelmChartRule = Struct.new(:chart_name, :version, keyword_init: true) do
+    def to_h
+      {
+        'matchDatasources' => ['helm'],
+        'matchPackageNames' => [chart_name],
+        'allowedVersions' => ImageVersionSet.new(
+          package_name: chart_name,
+          versions: [version]
+        ).allowed_versions_pattern
+      }
+    end
+  end
+
   OPERATORS = {
     'pxc' => OperatorConfig.new(
       name: 'pxc',
@@ -284,7 +301,11 @@ class PerconaDigestUpdater
       github_repo: 'percona/percona-postgresql-operator',
       docs_base_url: 'https://docs.percona.com/percona-operator-for-postgresql/latest/ReleaseNotes',
       docs_pattern: 'Kubernetes-Operator-for-PostgreSQL-RN%s.html',
-      config_file: 'percona-postgresql-versions.json'
+      config_file: 'percona-postgresql-versions.json',
+      helm_charts: [
+        'pg-db',
+        'pg-operator'
+      ]
     )
   }.freeze
 
@@ -403,20 +424,27 @@ class PerconaDigestUpdater
     package_rules = renovate_config['packageRules'] || []
 
     package_rules.reject! do |rule|
-      generated_image_rule?(rule)
+      generated_image_rule?(rule) || generated_helm_chart_rule?(rule)
     end
 
     certified_image_catalog.image_version_sets.each do |image_version_set|
       package_rules.concat(package_rules_for(image_version_set))
     end
 
+    @config.helm_chart_names.each do |chart_name|
+      package_rules << RenovateHelmChartRule.new(
+        chart_name: chart_name,
+        version: @version
+      ).to_h
+    end
+
     # Update the general Percona rule with all allowed versions
     package_rules.each do |rule|
       next unless percona_aggregate_rule?(rule)
 
-      rule['matchDatasources'] = ['docker']
-      rule['matchPackageNames'] = certified_image_catalog.package_names
-      rule['allowedVersions'] = certified_image_catalog.allowed_versions_pattern
+      rule['matchDatasources'] = aggregate_datasources
+      rule['matchPackageNames'] = aggregate_package_names(certified_image_catalog)
+      rule['allowedVersions'] = aggregate_allowed_versions_pattern(certified_image_catalog)
       rule['pinDigests'] = true
     end
 
@@ -512,11 +540,36 @@ class PerconaDigestUpdater
     package_names.any? { |name| name.include?('percona') }
   end
 
+  def aggregate_datasources
+    datasources = ['docker']
+    datasources << 'helm' unless @config.helm_chart_names.empty?
+    datasources
+  end
+
+  def aggregate_package_names(certified_image_catalog)
+    (certified_image_catalog.package_names + @config.helm_chart_names).sort
+  end
+
+  def aggregate_allowed_versions_pattern(certified_image_catalog)
+    ImageVersionSet.new(
+      package_name: 'aggregate',
+      versions: certified_image_catalog.image_version_sets.flat_map(&:versions) + [@version]
+    ).allowed_versions_pattern
+  end
+
   def generated_image_rule?(rule)
     package_names = rule['matchPackageNames']
     package_names &&
       package_names.one? &&
       package_names.first.start_with?('percona/') &&
+      !rule.key?('groupName')
+  end
+
+  def generated_helm_chart_rule?(rule)
+    package_names = rule['matchPackageNames']
+    package_names &&
+      package_names.one? &&
+      @config.helm_chart_names.include?(package_names.first) &&
       !rule.key?('groupName')
   end
 

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -294,7 +294,11 @@ class PerconaDigestUpdater
       github_repo: 'percona/percona-xtradb-cluster-operator',
       docs_base_url: 'https://docs.percona.com/percona-operator-for-mysql/pxc/ReleaseNotes',
       docs_pattern: 'Kubernetes-Operator-for-PXC-RN%s.html',
-      config_file: 'percona-pxc-versions.json'
+      config_file: 'percona-pxc-versions.json',
+      helm_charts: [
+        'pxc-db',
+        'pxc-operator'
+      ]
     ),
     'postgresql' => OperatorConfig.new(
       name: 'postgresql',

--- a/percona-postgresql-versions.json
+++ b/percona-postgresql-versions.json
@@ -12,11 +12,14 @@
         "percona/percona-pgbackrest",
         "percona/percona-pgbouncer",
         "percona/percona-postgresql-operator",
-        "percona/pmm-client"
+        "percona/pmm-client",
+        "pg-db",
+        "pg-operator"
       ],
       "allowedVersions": "/^(1\\.25\\.0\\-1|2\\.8\\.2|2\\.8\\.2\\-ppg13\\.23\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg14\\.20\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg15\\.15\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg16\\.11\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg17\\.7\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg18\\.1\\-postgres\\-gis3\\.5\\.4|2\\.44\\.1\\-1|2\\.57\\.0\\-1|3\\.5\\.0|13\\.23\\-2|14\\.20\\-2|15\\.15\\-2|16\\.11\\-2|17\\.7\\-2|18\\.1\\-3)$/",
       "matchDatasources": [
-        "docker"
+        "docker",
+        "helm"
       ],
       "pinDigests": true
     },
@@ -212,6 +215,24 @@
       "versioning": "semver",
       "allowedVersions": "/^(3\\.5\\.0)$/",
       "pinDigests": true
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pg-db"
+      ],
+      "allowedVersions": "/^(2\\.8\\.2)$/"
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pg-operator"
+      ],
+      "allowedVersions": "/^(2\\.8\\.2)$/"
     }
   ]
 }

--- a/percona-pxc-versions.json
+++ b/percona-pxc-versions.json
@@ -14,11 +14,14 @@
         "percona/percona-xtradb-cluster",
         "percona/percona-xtradb-cluster-operator",
         "percona/pmm-client",
-        "percona/proxysql2"
+        "percona/proxysql2",
+        "pxc-db",
+        "pxc-operator"
       ],
       "allowedVersions": "/^(1\\.18\\.0|2\\.4\\.29|2\\.7\\.3|2\\.8\\.15|2\\.44\\.1\\-1|3\\.3\\.1|4\\.0\\.1|5\\.7\\.34\\-31\\.51|5\\.7\\.36\\-31\\.55|5\\.7\\.39\\-31\\.61|5\\.7\\.42\\-31\\.65|5\\.7\\.44\\-31\\.65|8\\.0\\.35\\-27\\.1|8\\.0\\.35\\-34\\.1|8\\.0\\.36\\-28\\.1|8\\.0\\.39\\-30\\.1|8\\.0\\.41\\-32\\.1|8\\.0\\.42\\-33\\.1|8\\.4\\.0\\-3\\.1|8\\.4\\.5\\-5\\.1)$/",
       "matchDatasources": [
-        "docker"
+        "docker",
+        "helm"
       ],
       "pinDigests": true
     },
@@ -143,6 +146,24 @@
       "versioning": "semver",
       "allowedVersions": "/^(8\\.4\\.5\\-5\\.1)$/",
       "pinDigests": true
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pxc-db"
+      ],
+      "allowedVersions": "/^(1\\.18\\.0)$/"
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pxc-operator"
+      ],
+      "allowedVersions": "/^(1\\.18\\.0)$/"
     }
   ]
 }


### PR DESCRIPTION
This adds matching for Helm releases for both PXC and PosgreSQL releases.