### PR TITLE
Restrict Percona updates by digest

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Usage: `"extends": ["github>powerhome/renovate-config:ignore-reviewdog-action"]`
 ## Percona presets
 
 ### percona-postgresql-versions
-Restricts Percona PostgreSQL-related Docker updates to images certified together in the blessed Percona PostgreSQL Operator release.
+Restricts Percona PostgreSQL-related Docker and Helm chart updates to versions certified together in the blessed Percona PostgreSQL Operator release.
 
 Usage: `"extends": ["github>powerhome/renovate-config:percona-postgresql-versions"]`
 
@@ -131,11 +131,13 @@ This preset:
 
 - Groups Percona PostgreSQL dependency updates into one Renovate PR.
 - Restricts `allowedVersions` to the certified image versions from Percona's release notes.
+- Disables Docker updates whose proposed digest does not match the certified digest for the proposed image tag.
+- Restricts the `pg-db` and `pg-operator` Helm charts to the blessed Percona PostgreSQL Operator version.
 - Keeps PMM client updates on the current major version, so a project on PMM `2.x` is not offered PMM `3.x`.
 - Keeps PostgreSQL image updates on the current PostgreSQL major version. For example, a project on PostgreSQL 14 only matches approved PostgreSQL 14 image tags.
 
 ### percona-pxc-versions
-Restricts Percona PXC-related Docker updates to images certified together in the blessed Percona PXC Operator release.
+Restricts Percona PXC-related Docker and Helm chart updates to versions certified together in the blessed Percona PXC Operator release.
 
 Usage: `"extends": ["github>powerhome/renovate-config:percona-pxc-versions"]`
 
@@ -143,6 +145,8 @@ This preset:
 
 - Groups Percona PXC dependency updates into one Renovate PR.
 - Restricts `allowedVersions` to the certified image versions from Percona's release notes.
+- Disables Docker updates whose proposed digest does not match the certified digest for the proposed image tag.
+- Restricts the `pxc-db` and `pxc-operator` Helm charts to the blessed Percona PXC Operator version.
 - Keeps PXC and XtraBackup updates on the current MySQL compatibility line. For example, a project on `8.0.x` is not offered `8.4.x`, and a project on `5.7.x` is not offered `8.0.x`.
 
 ### Updating Percona presets

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -319,6 +319,7 @@ class PerconaDigestUpdater
   RenovateHelmChartRule = Struct.new(:chart_name, :version, keyword_init: true) do
     def to_h
       {
+        'description' => "Restrict #{chart_name} updates to the blessed Percona version",
         'matchDatasources' => ['helm'],
         'matchPackageNames' => [chart_name],
         'allowedVersions' => ImageVersionSet.new(

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -69,10 +69,18 @@ class PerconaDigestUpdater
         next unless certified_image.supported_architecture?
 
         image_key = [certified_image.package_name, certified_image.version]
-        next if seen_images[image_key]
+        if seen_images.key?(image_key)
+          if seen_images[image_key] != certified_image.digest
+            raise ReleaseParseError,
+                  "Conflicting certified digests found for #{certified_image.package_name}:#{certified_image.version} " \
+                  "at #{url}: #{seen_images[image_key]} and #{certified_image.digest}"
+          end
+
+          next
+        end
 
         certified_images << certified_image
-        seen_images[image_key] = true
+        seen_images[image_key] = certified_image.digest
       end
 
       unless certified_images.empty?

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -423,6 +423,9 @@ class PerconaDigestUpdater
   rescue JSON::ParserError => e
     raise ReleaseFetchError,
           "Failed to parse GitHub releases response for #{@config.name} from #{github_api_url}: #{e.message}"
+  rescue SocketError, SystemCallError, Timeout::Error, OpenSSL::SSL::SSLError => e
+    raise ReleaseFetchError,
+          "Failed to fetch GitHub releases for #{@config.name} from #{github_api_url}: #{e.class}: #{e.message}"
   end
 
   def fetch_release_notes
@@ -438,6 +441,10 @@ class PerconaDigestUpdater
     end
 
     response.body
+  rescue SocketError, SystemCallError, Timeout::Error, OpenSSL::SSL::SSLError => e
+    raise ReleaseFetchError,
+          "Failed to fetch release notes for #{@config.name} #{@version} from #{@release_notes_url}: " \
+          "#{e.class}: #{e.message}"
   end
 
   def parse_certified_image_catalog(html_content)

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -611,7 +611,7 @@ class PerconaDigestUpdater
   def aggregate_allowed_versions_pattern(certified_image_catalog)
     ImageVersionSet.new(
       package_name: 'aggregate',
-      versions: certified_image_catalog.image_version_sets.flat_map(&:versions) + [@version]
+      versions: certified_image_catalog.image_version_sets.flat_map(&:versions)
     ).allowed_versions_pattern
   end
 

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -15,13 +15,17 @@ class PerconaDigestUpdater
 
   DIGEST_PATTERN = /\A[a-f0-9]{64}\z/i
 
-  OperatorConfig = Struct.new(:name, :github_repo, :docs_base_url, :docs_pattern, :config_file, keyword_init: true) do
+  OperatorConfig = Struct.new(:name, :github_repo, :docs_base_url, :docs_pattern, :config_file, :helm_charts, keyword_init: true) do
     def release_notes_url(version)
       "#{docs_base_url}/#{docs_pattern % version}"
     end
 
     def display_name
       name.upcase
+    end
+
+    def helm_chart_names
+      helm_charts || []
     end
   end
 
@@ -96,6 +100,12 @@ class PerconaDigestUpdater
       end
     end
 
+    def image_digest_sets
+      grouped_images.map do |package_name, versions|
+        ImageDigestSet.new(package_name: package_name, version_digests: versions)
+      end
+    end
+
     def package_names
       image_version_sets.map(&:package_name).sort
     end
@@ -125,6 +135,19 @@ class PerconaDigestUpdater
     end
 
     private_class_method :text_from_html
+  end
+
+  ImageDigestSet = Struct.new(:package_name, :version_digests, keyword_init: true) do
+    def certified_digest_matcher
+      version_digests.map do |version, digest|
+        digest_matcher = [
+          digest,
+          "sha256:#{digest}"
+        ].map { |value| "newDigest = '#{value}'" }.join(' or ')
+
+        "(newVersion = '#{version}' and (#{digest_matcher}))"
+      end.join(' or ')
+    end
   end
 
   ImageVersionSet = Struct.new(:package_name, :versions, keyword_init: true) do
@@ -271,20 +294,55 @@ class PerconaDigestUpdater
     private_class_method :postgres_major_matcher
   end
 
+  RenovateDigestGateRule = Struct.new(:image_digest_set, keyword_init: true) do
+    def to_h
+      {
+        'description' => "Disable #{image_digest_set.package_name} updates that do not match Percona's certified image digest",
+        'matchDatasources' => ['docker'],
+        'matchPackageNames' => [image_digest_set.package_name],
+        'matchJsonata' => [
+          "$exists(newDigest) and $not(#{image_digest_set.certified_digest_matcher})"
+        ],
+        'enabled' => false
+      }
+    end
+  end
+
+  RenovateHelmChartRule = Struct.new(:chart_name, :version, keyword_init: true) do
+    def to_h
+      {
+        'matchDatasources' => ['helm'],
+        'matchPackageNames' => [chart_name],
+        'allowedVersions' => ImageVersionSet.new(
+          package_name: chart_name,
+          versions: [version]
+        ).allowed_versions_pattern
+      }
+    end
+  end
+
   OPERATORS = {
     'pxc' => OperatorConfig.new(
       name: 'pxc',
       github_repo: 'percona/percona-xtradb-cluster-operator',
       docs_base_url: 'https://docs.percona.com/percona-operator-for-mysql/pxc/ReleaseNotes',
       docs_pattern: 'Kubernetes-Operator-for-PXC-RN%s.html',
-      config_file: 'percona-pxc-versions.json'
+      config_file: 'percona-pxc-versions.json',
+      helm_charts: [
+        'pxc-db',
+        'pxc-operator'
+      ]
     ),
     'postgresql' => OperatorConfig.new(
       name: 'postgresql',
       github_repo: 'percona/percona-postgresql-operator',
       docs_base_url: 'https://docs.percona.com/percona-operator-for-postgresql/latest/ReleaseNotes',
       docs_pattern: 'Kubernetes-Operator-for-PostgreSQL-RN%s.html',
-      config_file: 'percona-postgresql-versions.json'
+      config_file: 'percona-postgresql-versions.json',
+      helm_charts: [
+        'pg-db',
+        'pg-operator'
+      ]
     )
   }.freeze
 
@@ -403,20 +461,33 @@ class PerconaDigestUpdater
     package_rules = renovate_config['packageRules'] || []
 
     package_rules.reject! do |rule|
-      generated_image_rule?(rule)
+      generated_image_rule?(rule) || generated_helm_chart_rule?(rule)
     end
 
     certified_image_catalog.image_version_sets.each do |image_version_set|
       package_rules.concat(package_rules_for(image_version_set))
     end
 
+    certified_image_catalog.image_digest_sets.each do |image_digest_set|
+      package_rules << RenovateDigestGateRule.new(
+        image_digest_set: image_digest_set
+      ).to_h
+    end
+
+    @config.helm_chart_names.each do |chart_name|
+      package_rules << RenovateHelmChartRule.new(
+        chart_name: chart_name,
+        version: @version
+      ).to_h
+    end
+
     # Update the general Percona rule with all allowed versions
     package_rules.each do |rule|
       next unless percona_aggregate_rule?(rule)
 
-      rule['matchDatasources'] = ['docker']
-      rule['matchPackageNames'] = certified_image_catalog.package_names
-      rule['allowedVersions'] = certified_image_catalog.allowed_versions_pattern
+      rule['matchDatasources'] = aggregate_datasources
+      rule['matchPackageNames'] = aggregate_package_names(certified_image_catalog)
+      rule['allowedVersions'] = aggregate_allowed_versions_pattern(certified_image_catalog)
       rule['pinDigests'] = true
     end
 
@@ -512,11 +583,36 @@ class PerconaDigestUpdater
     package_names.any? { |name| name.include?('percona') }
   end
 
+  def aggregate_datasources
+    datasources = ['docker']
+    datasources << 'helm' unless @config.helm_chart_names.empty?
+    datasources
+  end
+
+  def aggregate_package_names(certified_image_catalog)
+    (certified_image_catalog.package_names + @config.helm_chart_names).sort
+  end
+
+  def aggregate_allowed_versions_pattern(certified_image_catalog)
+    ImageVersionSet.new(
+      package_name: 'aggregate',
+      versions: certified_image_catalog.image_version_sets.flat_map(&:versions) + [@version]
+    ).allowed_versions_pattern
+  end
+
   def generated_image_rule?(rule)
     package_names = rule['matchPackageNames']
     package_names &&
       package_names.one? &&
       package_names.first.start_with?('percona/') &&
+      !rule.key?('groupName')
+  end
+
+  def generated_helm_chart_rule?(rule)
+    package_names = rule['matchPackageNames']
+    package_names &&
+      package_names.one? &&
+      @config.helm_chart_names.include?(package_names.first) &&
       !rule.key?('groupName')
   end
 

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -504,7 +504,12 @@ class PerconaDigestUpdater
       rule['matchDatasources'] = aggregate_datasources
       rule['matchPackageNames'] = aggregate_package_names(certified_image_catalog)
       rule['allowedVersions'] = aggregate_allowed_versions_pattern(certified_image_catalog)
-      rule['pinDigests'] = true
+
+      if @config.helm_chart_names.any?
+        rule.delete('pinDigests')
+      else
+        rule['pinDigests'] = true
+      end
     end
 
     renovate_config['packageRules'] = package_rules

--- a/bin/update_percona_digests.rb
+++ b/bin/update_percona_digests.rb
@@ -319,7 +319,7 @@ class PerconaDigestUpdater
   RenovateHelmChartRule = Struct.new(:chart_name, :version, keyword_init: true) do
     def to_h
       {
-        'description' => "Restrict #{chart_name} updates to the blessed Percona version",
+        'description' => "Restrict Helm chart #{chart_name} to Percona's certified operator version",
         'matchDatasources' => ['helm'],
         'matchPackageNames' => [chart_name],
         'allowedVersions' => ImageVersionSet.new(
@@ -625,10 +625,8 @@ class PerconaDigestUpdater
   end
 
   def generated_helm_chart_rule?(rule)
-    package_names = rule['matchPackageNames']
-    package_names &&
-      package_names.one? &&
-      @config.helm_chart_names.include?(package_names.first) &&
+    rule['description']&.start_with?('Restrict Helm chart ') &&
+      rule['matchPackageNames']&.one? &&
       !rule.key?('groupName')
   end
 

--- a/percona-postgresql-versions.json
+++ b/percona-postgresql-versions.json
@@ -282,6 +282,7 @@
       "enabled": false
     },
     {
+      "description": "Restrict Helm chart pg-db to Percona's certified operator version",
       "matchDatasources": [
         "helm"
       ],
@@ -291,6 +292,7 @@
       "allowedVersions": "/^(2\\.8\\.2)$/"
     },
     {
+      "description": "Restrict Helm chart pg-operator to Percona's certified operator version",
       "matchDatasources": [
         "helm"
       ],

--- a/percona-postgresql-versions.json
+++ b/percona-postgresql-versions.json
@@ -12,11 +12,14 @@
         "percona/percona-pgbackrest",
         "percona/percona-pgbouncer",
         "percona/percona-postgresql-operator",
-        "percona/pmm-client"
+        "percona/pmm-client",
+        "pg-db",
+        "pg-operator"
       ],
       "allowedVersions": "/^(1\\.25\\.0\\-1|2\\.8\\.2|2\\.8\\.2\\-ppg13\\.23\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg14\\.20\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg15\\.15\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg16\\.11\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg17\\.7\\-postgres\\-gis3\\.3\\.8|2\\.8\\.2\\-ppg18\\.1\\-postgres\\-gis3\\.5\\.4|2\\.44\\.1\\-1|2\\.57\\.0\\-1|3\\.5\\.0|13\\.23\\-2|14\\.20\\-2|15\\.15\\-2|16\\.11\\-2|17\\.7\\-2|18\\.1\\-3)$/",
       "matchDatasources": [
-        "docker"
+        "docker",
+        "helm"
       ],
       "pinDigests": true
     },
@@ -212,6 +215,89 @@
       "versioning": "semver",
       "allowedVersions": "/^(3\\.5\\.0)$/",
       "pinDigests": true
+    },
+    {
+      "description": "Disable percona/percona-postgresql-operator updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-postgresql-operator"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '2.8.2' and (newDigest = '018b0063352fff83d7850d732c80ba6a938c425ac2d9ac7e9a0a270361ff3fc0' or newDigest = 'sha256:018b0063352fff83d7850d732c80ba6a938c425ac2d9ac7e9a0a270361ff3fc0')) or (newVersion = '2.8.2-ppg18.1-postgres-gis3.5.4' and (newDigest = 'a9c58611e1660a1377a579370c0684a5bc12a37df69031bdcf7dac5332d016ad' or newDigest = 'sha256:a9c58611e1660a1377a579370c0684a5bc12a37df69031bdcf7dac5332d016ad')) or (newVersion = '2.8.2-ppg17.7-postgres-gis3.3.8' and (newDigest = '64246fa0fe2213f2321bdd565181578fd84e8d745b044553b60d45c41dbf3e5c' or newDigest = 'sha256:64246fa0fe2213f2321bdd565181578fd84e8d745b044553b60d45c41dbf3e5c')) or (newVersion = '2.8.2-ppg16.11-postgres-gis3.3.8' and (newDigest = 'd4467fe931e6403538a1f9831c7c97f84177027bfb226a9a7e021026506bb4d7' or newDigest = 'sha256:d4467fe931e6403538a1f9831c7c97f84177027bfb226a9a7e021026506bb4d7')) or (newVersion = '2.8.2-ppg15.15-postgres-gis3.3.8' and (newDigest = 'd9680938ae31bc0c2d1fd89cda306b1bdb9b4aef424d706896460de71a2311e2' or newDigest = 'sha256:d9680938ae31bc0c2d1fd89cda306b1bdb9b4aef424d706896460de71a2311e2')) or (newVersion = '2.8.2-ppg14.20-postgres-gis3.3.8' and (newDigest = '71947a799ea4e957bf6a9dd6a4ff055037a335d9d71186452b64e05d1ce68c38' or newDigest = 'sha256:71947a799ea4e957bf6a9dd6a4ff055037a335d9d71186452b64e05d1ce68c38')) or (newVersion = '2.8.2-ppg13.23-postgres-gis3.3.8' and (newDigest = '9b75f33ee9d7e95a0d9ea9e619533878d92814183a0ed9ad59bc69813b11a84d' or newDigest = 'sha256:9b75f33ee9d7e95a0d9ea9e619533878d92814183a0ed9ad59bc69813b11a84d')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/percona-distribution-postgresql updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-distribution-postgresql"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '18.1-3' and (newDigest = '940859b7c45d1217ba852e8c5e5500832daf61c6914d5af33808251cb23f0102' or newDigest = 'sha256:940859b7c45d1217ba852e8c5e5500832daf61c6914d5af33808251cb23f0102')) or (newVersion = '17.7-2' and (newDigest = '7beb6a0d9fd4c4e8125c5cb43c48e8b189a4dca7b4f1ec1e433b49956d4203d6' or newDigest = 'sha256:7beb6a0d9fd4c4e8125c5cb43c48e8b189a4dca7b4f1ec1e433b49956d4203d6')) or (newVersion = '16.11-2' and (newDigest = '80882a55997c58b7a4dd5defc6482d99dc31c11fbd206f788e540a74ffab4823' or newDigest = 'sha256:80882a55997c58b7a4dd5defc6482d99dc31c11fbd206f788e540a74ffab4823')) or (newVersion = '15.15-2' and (newDigest = '100ef9920d70d0ff53a0466f9b077ba3f1828c31b330a08a6e6e11802b870178' or newDigest = 'sha256:100ef9920d70d0ff53a0466f9b077ba3f1828c31b330a08a6e6e11802b870178')) or (newVersion = '14.20-2' and (newDigest = '011bae00abeb266352aa6c8e127396b0a3fb5877f0112f5291172624b5556120' or newDigest = 'sha256:011bae00abeb266352aa6c8e127396b0a3fb5877f0112f5291172624b5556120')) or (newVersion = '13.23-2' and (newDigest = '39ef40f72704e8e782ed43fb5a5072ee557fd410b85b9d2177b332ce39b888f5' or newDigest = 'sha256:39ef40f72704e8e782ed43fb5a5072ee557fd410b85b9d2177b332ce39b888f5')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/percona-pgbouncer updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-pgbouncer"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '1.25.0-1' and (newDigest = 'bf2f325cc733b96dc360c2386c8931ed9e3513f55cb425e59033e1e56737134f' or newDigest = 'sha256:bf2f325cc733b96dc360c2386c8931ed9e3513f55cb425e59033e1e56737134f')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/percona-pgbackrest updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-pgbackrest"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '2.57.0-1' and (newDigest = '2bf7265f84210671bc5c0928cc772202c0e6054d426eb6ecf86279d69e831b96' or newDigest = 'sha256:2bf7265f84210671bc5c0928cc772202c0e6054d426eb6ecf86279d69e831b96')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/pmm-client updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/pmm-client"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '2.44.1-1' and (newDigest = '52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3' or newDigest = 'sha256:52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3')) or (newVersion = '3.5.0' and (newDigest = '352aee74f25b3c1c4cd9dff1f378a0c3940b315e551d170c09953bf168531e4a' or newDigest = 'sha256:352aee74f25b3c1c4cd9dff1f378a0c3940b315e551d170c09953bf168531e4a')))"
+      ],
+      "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pg-db"
+      ],
+      "allowedVersions": "/^(2\\.8\\.2)$/"
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pg-operator"
+      ],
+      "allowedVersions": "/^(2\\.8\\.2)$/"
     }
   ]
 }

--- a/percona-postgresql-versions.json
+++ b/percona-postgresql-versions.json
@@ -20,8 +20,7 @@
       "matchDatasources": [
         "docker",
         "helm"
-      ],
-      "pinDigests": true
+      ]
     },
     {
       "matchDatasources": [

--- a/percona-pxc-versions.json
+++ b/percona-pxc-versions.json
@@ -239,6 +239,7 @@
       "enabled": false
     },
     {
+      "description": "Restrict Helm chart pxc-db to Percona's certified operator version",
       "matchDatasources": [
         "helm"
       ],
@@ -248,6 +249,7 @@
       "allowedVersions": "/^(1\\.18\\.0)$/"
     },
     {
+      "description": "Restrict Helm chart pxc-operator to Percona's certified operator version",
       "matchDatasources": [
         "helm"
       ],

--- a/percona-pxc-versions.json
+++ b/percona-pxc-versions.json
@@ -22,8 +22,7 @@
       "matchDatasources": [
         "docker",
         "helm"
-      ],
-      "pinDigests": true
+      ]
     },
     {
       "matchDatasources": [

--- a/percona-pxc-versions.json
+++ b/percona-pxc-versions.json
@@ -14,11 +14,14 @@
         "percona/percona-xtradb-cluster",
         "percona/percona-xtradb-cluster-operator",
         "percona/pmm-client",
-        "percona/proxysql2"
+        "percona/proxysql2",
+        "pxc-db",
+        "pxc-operator"
       ],
       "allowedVersions": "/^(1\\.18\\.0|2\\.4\\.29|2\\.7\\.3|2\\.8\\.15|2\\.44\\.1\\-1|3\\.3\\.1|4\\.0\\.1|5\\.7\\.34\\-31\\.51|5\\.7\\.36\\-31\\.55|5\\.7\\.39\\-31\\.61|5\\.7\\.42\\-31\\.65|5\\.7\\.44\\-31\\.65|8\\.0\\.35\\-27\\.1|8\\.0\\.35\\-34\\.1|8\\.0\\.36\\-28\\.1|8\\.0\\.39\\-30\\.1|8\\.0\\.41\\-32\\.1|8\\.0\\.42\\-33\\.1|8\\.4\\.0\\-3\\.1|8\\.4\\.5\\-5\\.1)$/",
       "matchDatasources": [
-        "docker"
+        "docker",
+        "helm"
       ],
       "pinDigests": true
     },
@@ -143,6 +146,115 @@
       "versioning": "semver",
       "allowedVersions": "/^(8\\.4\\.5\\-5\\.1)$/",
       "pinDigests": true
+    },
+    {
+      "description": "Disable percona/percona-xtradb-cluster-operator updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-xtradb-cluster-operator"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '1.18.0' and (newDigest = '0eca0b096482c7d09792c15fee00dbdcd0fbf3cd487dab60eb2774b025681e85' or newDigest = 'sha256:0eca0b096482c7d09792c15fee00dbdcd0fbf3cd487dab60eb2774b025681e85')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/haproxy updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/haproxy"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '2.8.15' and (newDigest = '49e6987a1c8b27e9111ae1f1168dd51f2840eb6d939ffc157358f0f259819006' or newDigest = 'sha256:49e6987a1c8b27e9111ae1f1168dd51f2840eb6d939ffc157358f0f259819006')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/proxysql2 updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/proxysql2"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '2.7.3' and (newDigest = '51fedf9de05e4f130d5b08388511536fb1e1050a24ffc21bedb0f0b61a236567' or newDigest = 'sha256:51fedf9de05e4f130d5b08388511536fb1e1050a24ffc21bedb0f0b61a236567')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/percona-xtrabackup updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-xtrabackup"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '8.4.0-3.1' and (newDigest = '01071522753ad94e11a897859bba4713316d08e493e23555c0094d68da223730' or newDigest = 'sha256:01071522753ad94e11a897859bba4713316d08e493e23555c0094d68da223730')) or (newVersion = '8.0.35-34.1' and (newDigest = '2dc127b08971051296d421b22aa861bb0330cf702b4b0246ae31053b0f01911e' or newDigest = 'sha256:2dc127b08971051296d421b22aa861bb0330cf702b4b0246ae31053b0f01911e')) or (newVersion = '2.4.29' and (newDigest = '11b92a7f7362379fc6b0de92382706153f2ac007ebf0d7ca25bac2c7303fdf10' or newDigest = 'sha256:11b92a7f7362379fc6b0de92382706153f2ac007ebf0d7ca25bac2c7303fdf10')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/fluentbit updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/fluentbit"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '4.0.1' and (newDigest = 'a4ab7dd10379ccf74607f6b05225c4996eeff53b628bda94e615781a1f58b779' or newDigest = 'sha256:a4ab7dd10379ccf74607f6b05225c4996eeff53b628bda94e615781a1f58b779')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/pmm-client updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/pmm-client"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '3.3.1' and (newDigest = '29a9bb1c69fef8bedc4d4a9ed0ae8224a8623fd3eb8676ef40b13fd044188cb4' or newDigest = 'sha256:29a9bb1c69fef8bedc4d4a9ed0ae8224a8623fd3eb8676ef40b13fd044188cb4')) or (newVersion = '2.44.1-1' and (newDigest = '52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3' or newDigest = 'sha256:52a8fb5e8f912eef1ff8a117ea323c401e278908ce29928dafc23fac1db4f1e3')))"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Disable percona/percona-xtradb-cluster updates that do not match Percona's certified image digest",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "percona/percona-xtradb-cluster"
+      ],
+      "matchJsonata": [
+        "$exists(newDigest) and $not((newVersion = '8.4.5-5.1' and (newDigest = '918c54c11c96bf61bb3f32315ef6b344b7b1d68a0457a47a3804eca3932b2b17' or newDigest = 'sha256:918c54c11c96bf61bb3f32315ef6b344b7b1d68a0457a47a3804eca3932b2b17')) or (newVersion = '8.0.42-33.1' and (newDigest = '476851339090e44bb72760ae718fc36beb73a6028a29459e849271649018d546' or newDigest = 'sha256:476851339090e44bb72760ae718fc36beb73a6028a29459e849271649018d546')) or (newVersion = '8.0.41-32.1' and (newDigest = 'd9c84884a12631306d5a33a079e30bf7b65d3d380b07b397d7b1b6a642cc6bff' or newDigest = 'sha256:d9c84884a12631306d5a33a079e30bf7b65d3d380b07b397d7b1b6a642cc6bff')) or (newVersion = '8.0.39-30.1' and (newDigest = '6a53a6ad4e7d2c2fb404d274d993414a22cb67beecf7228df9d5d994e7a09966' or newDigest = 'sha256:6a53a6ad4e7d2c2fb404d274d993414a22cb67beecf7228df9d5d994e7a09966')) or (newVersion = '8.0.36-28.1' and (newDigest = 'b5cc4034ccfb0186d6a734cb749ae17f013b027e9e64746b2c876e8beef379b3' or newDigest = 'sha256:b5cc4034ccfb0186d6a734cb749ae17f013b027e9e64746b2c876e8beef379b3')) or (newVersion = '8.0.35-27.1' and (newDigest = '1ef24953591ef1c1ce39576843d5615d4060fd09458c7a39ebc3e2eda7ef486b' or newDigest = 'sha256:1ef24953591ef1c1ce39576843d5615d4060fd09458c7a39ebc3e2eda7ef486b')) or (newVersion = '5.7.44-31.65' and (newDigest = '36fafdef46485839d4ff7c6dc73b4542b07031644c0152e911acb9734ff2be85' or newDigest = 'sha256:36fafdef46485839d4ff7c6dc73b4542b07031644c0152e911acb9734ff2be85')) or (newVersion = '5.7.42-31.65' and (newDigest = '9dab86780f86ec9caf8e1032a563c131904b75a37edeaec159a93f7d0c16c603' or newDigest = 'sha256:9dab86780f86ec9caf8e1032a563c131904b75a37edeaec159a93f7d0c16c603')) or (newVersion = '5.7.39-31.61' and (newDigest = '9013170a71559bbac92ba9c2e986db9bda3a8a9e39ee1ee350e0ee94488bb6d7' or newDigest = 'sha256:9013170a71559bbac92ba9c2e986db9bda3a8a9e39ee1ee350e0ee94488bb6d7')) or (newVersion = '5.7.36-31.55' and (newDigest = 'c7bad990fc7ca0fde89240e921052f49da08b67c7c6dc54239593d61710be504' or newDigest = 'sha256:c7bad990fc7ca0fde89240e921052f49da08b67c7c6dc54239593d61710be504')) or (newVersion = '5.7.34-31.51' and (newDigest = 'f8d51d7932b9bb1a5a896c7ae440256230eb69b55798ff37397aabfd58b80ccb' or newDigest = 'sha256:f8d51d7932b9bb1a5a896c7ae440256230eb69b55798ff37397aabfd58b80ccb')))"
+      ],
+      "enabled": false
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pxc-db"
+      ],
+      "allowedVersions": "/^(1\\.18\\.0)$/"
+    },
+    {
+      "matchDatasources": [
+        "helm"
+      ],
+      "matchPackageNames": [
+        "pxc-operator"
+      ],
+      "allowedVersions": "/^(1\\.18\\.0)$/"
     }
   ]
 }


### PR DESCRIPTION
Now that we can see how this is working in production across multiple repos to stop suggesting updates to newer versions of Percona images than our CRDs can support, this PR iterates on the original idea by using the [matchJsonata](https://docs.renovatebot.com/configuration-options/#packagerulesmatchjsonata) feature for package rules to pin specific digests in addition to just the versions.