### PR TITLE
Fix custom manager for pac-deployer image

### DIFF
--- a/deployer-image-versioning.json
+++ b/deployer-image-versioning.json
@@ -10,25 +10,10 @@
                 "/\\.sh$/"
             ],
             "matchStrings": [
-                "(?<prefix>DEPLOYER_IMAGE\\s*=\\s*[\"']?image-registry\\.powerapp\\.cloud/app/deployer:)(?:latest|(?:main|master)-[a-f0-9]{40}-\\d+|PR-\\d+-[a-f0-9]{40}-\\d+(?:-amd64)?)"
+                "(?<prefix>(?:DEPLOYER_IMAGE\\s*=\\s*[\"']?|image:\\s*[\"']?|docker image inspect\\s+)image-registry\\.powerapp\\.cloud/app/deployer:)(?:latest|(?:main|master)-[a-f0-9]{40}-\\d+|PR-\\d+-[a-f0-9]{40}-\\d+(?:-amd64)?)",
+                "(?<prefix>(?:DEPLOYER_IMAGE\\s*=\\s*[\"']?|image:\\s*[\"']?|docker image inspect\\s+)image-registry\\.powerapp\\.cloud/app/deployer:)(?<currentValue>v\\d+\\.\\d+\\.\\d+)(?:@sha256:[a-f0-9]{64})?"
             ],
-            "currentValueTemplate": "0.0.0",
-            "datasourceTemplate": "github-releases",
-            "depNameTemplate": "powerhome/pac-deployer",
-            "autoReplaceStringTemplate": "{{{prefix}}}{{{newValue}}}"
-        },
-        {
-            "customType": "regex",
-            "managerFilePatterns": [
-                "/(^|/)bin/.*$/",
-                "/(^|/)deploy/.*$/",
-                "/(^|/)scripts?/.*$/",
-                "/(^|/)[^/.]+$/",
-                "/\\.sh$/"
-            ],
-            "matchStrings": [
-                "(?<prefix>DEPLOYER_IMAGE\\s*=\\s*[\"']?image-registry\\.powerapp\\.cloud/app/deployer:)(?<currentValue>v\\d+\\.\\d+\\.\\d+)"
-            ],
+            "currentValueTemplate": "{{#if currentValue}}{{{currentValue}}}{{else}}0.0.0{{/if}}",
             "datasourceTemplate": "github-releases",
             "depNameTemplate": "powerhome/pac-deployer",
             "autoReplaceStringTemplate": "{{{prefix}}}{{{newValue}}}"


### PR DESCRIPTION
## Summary

Updates the `deployer-image-versioning` Renovate preset so pac-deployer image references are handled by a single regex custom manager.

This expands matching for deployer image references in:
- `DEPLOYER_IMAGE=...` script assignments
- `image: "image-registry.powerapp.cloud/app/deployer:..."` deploy template references
- `docker image inspect image-registry.powerapp.cloud/app/deployer:...` script checks

It also supports existing `vX.Y.Z@sha256:...` references by consuming the old digest during replacement, so Renovate does not leave a stale digest attached to a newer tag.

## Motivation

The initial deployer image rule split legacy tags and versioned release tags across two custom managers. Renovate could extract and replace a legacy tag, but then failed branch creation because the same manager could not re-extract the updated `vX.Y.Z` value after autoreplace.

This caused runs like `powerhome/example-rails-app` to report:

> Could not extract deploy/bin/deployer (manager=regex) after autoreplace

The rule also needed to cover more of the real deployer image references used across Power repos, especially shell scripts, Makefiles, and deploy templates.

## Expected Outcome

Renovate should now be able to migrate legacy deployer image tags such as:

- `latest`
- `main-<sha>-<build>`
- `master-<sha>-<build>`
- `PR-<number>-<sha>-<build>`

to the latest `powerhome/pac-deployer` GitHub release tag, currently `v2.0.0`.

Future `vX.Y.Z` deployer references should continue to be updated from GitHub releases without hitting the post-autoreplace extraction failure.

This intentionally does not pin Docker digests. Digest pinning would require registry access or a separate release metadata flow, and we decided to keep this PR focused on stable release tag updates.

## Validation

- Ran `renovate-config-validator renovate.json`
- Ran `renovate-config-validator deployer-image-versioning.json`
- Tested representative deployer image reference shapes locally
- Checked [targeted GitHub code search results](https://github.com/search?q=org%3Apowerhome+image-registry.powerapp.cloud%2Fapp%2Fdeployer+%28language%3AHTML%2BERB+OR+language%3ASHELL+OR+language%3AMakefile%29++NOT+is%3Aarchived&type=code) for shell, Makefile, and HTML+ERB references