### PR TITLE
[GOG-1931] Add ci-kubed-read-token preset for public repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Allows Renovate the ability to bump ci-kubed versions in Jenkinsfiles.
 
 Usage: `"extends": ["github>powerhome/renovate-config:ci-kubed-versioning"]`
 
+## ci-kubed-read-token
+Adds a repo-scoped hostRule so the github-releases lookup for powerhome/ci-kubed uses a narrowly-scoped read token instead of the repo's default Renovate job token.
+
+This is only needed by **public** repos. Mend issues public repos' Renovate jobs a GitHub App token scoped to that one repo only (a security measure so a leaked token can't reach private org repos), so the github-releases datasource can't resolve the private ci-kubed repo without this override. Private repos get a broader-scoped token already and don't need it.
+
+Usage: `"extends": ["github>powerhome/renovate-config:ci-kubed-read-token"]`
+
 ## deployer-image-versioning
 Allows Renovate the ability to bump pac-deployer image versions in deployer bash scripts.
 Legacy `main-<sha>-<build>` and `master-<sha>-<build>` tags are migrated to

--- a/ci-kubed-read-token.json
+++ b/ci-kubed-read-token.json
@@ -1,0 +1,9 @@
+{
+    "hostRules": [
+        {
+            "matchHost": "https://api.github.com/repos/powerhome/ci-kubed",
+            "hostType": "github-releases",
+            "token": "{{ secrets.CI_KUBED_READ_TOKEN }}"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary

Public repos get a Mend-issued Renovate token scoped only to themselves, so the `github-releases` datasource lookup for the private `powerhome/ci-kubed` repo fails (used by the `ci-kubed-versioning` Jenkinsfile regex manager, already part of the `default` preset). Private repos get a broader-scoped token that includes `ci-kubed` already, so they're unaffected.

This adds a new opt-in preset, `ci-kubed-read-token`, with a repo-scoped `hostRules` entry so the `github-releases` lookup for `powerhome/ci-kubed` uses a narrowly-scoped read token instead of the repo's default job token.

It's deliberately **not** added to the `default` preset — each public repo needs a `CI_KUBED_READ_TOKEN` Mend-hosted repo secret configured before this can take effect (Mend portal → repo settings → Credentials; Mend cannot read GitHub Actions secrets), so applying it globally would break the interpolation for every repo that hasn't set that secret up.

## Follow-up

Searched public `powerhome` repos for Jenkinsfiles referencing `ci-kubed`. Two matches:
- `powerhome/keess` — already has this exact `hostRules` block inline (PR #121) and has the `CI_KUBED_READ_TOKEN` secret configured. Once this preset merges, keess's renovate.json can drop the inline block and extend this preset instead.
- `powerhome/playbook` — same Jenkinsfile pattern (`library 'github.com/powerhome/ci-kubed@...'`), likely hitting the same lookup failure. Will need the `CI_KUBED_READ_TOKEN` secret added and `"github>powerhome/renovate-config:ci-kubed-read-token"` added to its `extends`.

## Context

<a href="https://runway.powerhrg.com/backlog_items/GOG-1931">GOG-1931</a>

## Test plan

- [ ] Extend this preset in keess and playbook, confirm the `github-releases` lookup for `ci-kubed` succeeds